### PR TITLE
Add interrogate

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Python project templates or project generators supporting `pyproject.toml`.
 - [Autohooks](https://github.com/greenbone/autohooks/blob/master/README.md#1-choosing-an-autohooks-mode) - Library for managing git hooks.
 - [Commitizen](https://commitizen-tools.github.io/commitizen/config/) - Create commiting rules for projects, auto bump versions and auto changelog generation.
 - [django-pyproject](https://github.com/Ceterai/django-pyproject) - Django package to store some or all of your settings in your pyproject.toml file.
+- [interrogate](https://github.com/econchick/interrogate) - Interrogate a codebase for docstring coverage.
 - [Poetrify](https://github.com/kk6/poetrify) - Convert a Pipfile (or requirements.txt) to pyproject.toml for Poetry.
 - [poetry-setup](https://github.com/orsinium/poetry-setup) - Generate setup.py (setuptools) from pyproject.toml.
 - [poetry-version](https://github.com/rominf/poetry-version) - Python library for extracting version from poetry pyproject.toml file.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Python project templates or project generators supporting `pyproject.toml`.
 - [Autohooks](https://github.com/greenbone/autohooks/blob/master/README.md#1-choosing-an-autohooks-mode) - Library for managing git hooks.
 - [Commitizen](https://commitizen-tools.github.io/commitizen/config/) - Create commiting rules for projects, auto bump versions and auto changelog generation.
 - [django-pyproject](https://github.com/Ceterai/django-pyproject) - Django package to store some or all of your settings in your pyproject.toml file.
-- [interrogate](https://github.com/econchick/interrogate) - Interrogate a codebase for docstring coverage.
+- [interrogate](https://interrogate.readthedocs.io/en/latest/#other-usage) - Interrogate a codebase for docstring coverage.
 - [Poetrify](https://github.com/kk6/poetrify) - Convert a Pipfile (or requirements.txt) to pyproject.toml for Poetry.
 - [poetry-setup](https://github.com/orsinium/poetry-setup) - Generate setup.py (setuptools) from pyproject.toml.
 - [poetry-version](https://github.com/rominf/poetry-version) - Python library for extracting version from poetry pyproject.toml file.


### PR DESCRIPTION
### Resource description
`interrogate` is the tool to measure docstring coverage (like for tests, but for documentation). It supports configuring via `pyproject.toml`.
### By submitting this pull request I confirm I've read and complied with the below requirements:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
