### PR TITLE
Add poe

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Python project templates or project generators supporting `pyproject.toml`.
 - [Commitizen](https://commitizen-tools.github.io/commitizen/config/) - Create commiting rules for projects, auto bump versions and auto changelog generation.
 - [datamodel-code-genrator](https://koxudaxi.github.io/datamodel-code-generator/pyproject_toml/) - Creates Pydantic data-model code from OpenAPI/JSON Schema files.
 - [django-pyproject](https://github.com/Ceterai/django-pyproject) - Django package to store some or all of your settings in your pyproject.toml file.
+- [Poe the Poet](https://github.com/nat-n/poethepoet#define-tasks-in-your-pyprojecttoml) - A task runner that works well with Poetry.
 - [Poetrify](https://github.com/kk6/poetrify) - Convert a Pipfile (or requirements.txt) to pyproject.toml for Poetry.
 - [poetry-setup](https://github.com/orsinium/poetry-setup) - Generate setup.py (setuptools) from pyproject.toml.
 - [poetry-version](https://github.com/rominf/poetry-version) - Python library for extracting version from poetry pyproject.toml file.


### PR DESCRIPTION
Further to discussion at #32 

### Resource description

Poe the Poet is a task runner that works well with poetry. You define tasks in the pyproject.toml like so:

```toml
[tool.poe.tasks]
test       = "pytest --cov=poethepoet"                                # simple command based task
mksandwich = { script = "my_package.sandwich:build" }                 # python script based task
tunnel     = { shell = "ssh -N -L 0.0.0.0:8080:$PROD:8080 $PROD &" }  # shell script based task
```

and then run them with the poe executable like so:

```bash
poe test
```

The task will be executed inside the poetry managed virtualenv, so no need to specify `poetry run` anywhere.

### By submitting this pull request I confirm I've read and complied with the below requirements

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
