### PR TITLE
Add ppsetuptools to packaging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Do you know of any other project not included here? Please
 - [Flit](https://flit.readthedocs.io/en/stable/pyproject_toml.html) - A simple way to put Python packages and modules on PyPI.
 - [Maturin](https://github.com/PyO3/maturin/blob/master/Readme.md#pyprojecttoml) - Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages.
 - [pip](https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support) - The package installer for Python. You can use pip to install packages from the Python Package Index and other indexes.
+- [ppsetuptools](https://github.com/TheCleric/ppsetuptools) - A drop-in replacement for python setuptools that uses pyproject.toml files
 - [Poetry](https://python-poetry.org/docs/pyproject/) - A tool for dependency management and packaging in Python. It allows you to declare the libraries your project depends on and it will manage (install/update) them for you.
 - [Pyflow](https://github.com/David-OConnor/pyflow) - An installation and dependency system for Python.
 - [setuptools_scm](https://github.com/pypa/setuptools_scm) - Handles managing your Python package versions in SCM metadata instead of declaring them as the version argument or in a SCM managed file.


### PR DESCRIPTION
I've developed a package that I think would be a good addition for this list: ppsetuptools. It is a straightforward drop-in replacement for setuptools that reads from a pyproject.toml file instead of having project metadata defined in a setup.py script.


<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->

ppsetuptools is a drop-in replacement for python setuptools that uses pyproject.toml files for package metadata instead of the setup.py

### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [X] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [X] I am making an individual pull request for each entry
- [X] I have added a useful title to the commit
- [X] I have added a useful title to this PR
- [X] I have added the new entry in alphabetical order
- [X] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [X] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
