### PR TITLE
Use ruby/setup-ruby

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.4'
     - run: gem install awesome_bot


### PR DESCRIPTION
[actions/setup-ruby](https://github.com/actions/setup-ruby) is deprecated, and [ruby/setup-ruby](https://github.com/ruby/setup-ruby) is the recommended replacement.

See https://github.com/actions/setup-ruby/issues/97 for more information

### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [X] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [ ] I am making an individual pull request for each entry
- [X] I have added a useful title to the commit
- [X] I have added a useful title to this PR
- [ ] I have added the new entry in alphabetical order
- [ ] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [ ] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
