### PR TITLE
Added entry for pydocstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Do you know of any other project not included here? Please
 - [interrogate](https://interrogate.readthedocs.io/en/latest/#other-usage) - Interrogate a codebase for docstring coverage.
 - [Mypy](https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file) - An optional static type checker for Python (PEP 484).
 - [Nitpick](https://nitpick.readthedocs.io/en/latest/configuration.html) - Flake8 plugin to enforce the same tool configuration (flake8, isort, mypy, Pylint...) across multiple Python projects.
+- [pydocstyle](https://www.pydocstyle.org/en/stable/usage.html#configuration-files) - A static analysis tool for checking compliance with Python docstring conventions.
 - [Pylint](http://pylint.pycqa.org/en/latest/user_guide/run.html?highlight=pyproject#command-line-options) - A tool that checks for errors in Python code, tries to enforce a coding standard and looks for code smells.
 - [pytest-pylint](https://github.com/carsongee/pytest-pylint/pull/107) - A pytest plugin for running pylint against your codebase.
 - [Unimport](https://github.com/hakancelik96/unimport/blob/master/README.md#configuring-unimport) - Detects unused python libraries.


### PR DESCRIPTION
pydocstyle added pyproject.toml support in version 6.1.0.
This was added by PR [#534](https://github.com/PyCQA/pydocstyle/pull/534).

<!-- Thank you for submitting a new resource to this list! -->

### Resource description

pydocstyle is a static analysis tool for checking compliance with Python docstring conventions.
pydocstyle supports most of PEP 257 out of the box, but it should not be considered a reference implementation.

It can be used standalone, and also as a plugin for flake8.

### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
