### PR TITLE
Add PEP 660 and movr 650 to Withdrawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ tool-specific files.
 
 - [PEP 518 -- File specification](https://www.python.org/dev/peps/pep-0518/#specification).
 - [PEP 621 -- Storing project metadata in pyproject.toml](https://www.python.org/dev/peps/pep-0621/#specification)
+- [PEP 660 -- Editable installs for pyproject.toml based builds (wheel based)](https://peps.python.org/pep-0660/)
 
 We think `pyproject.toml` is pretty awesome, so this
 [awesome list](https://github.com/topics/awesome-list) contains projects already
@@ -126,12 +127,13 @@ Python project templates or project generators supporting `pyproject.toml`.
 
 Python Enhancement Proposals (PEPs) still under consideration related to pyproject.toml.
 
-- [PEP 650 – Specifying Installer Requirements for Python Projects](https://www.python.org/dev/peps/pep-0650/)
+- None at the moment
 
-### Rejected/Superseded
+### Rejected/Withdrawn/Superseded
 
 - [PEP 631 – Dependency specification in pyproject.toml based on PEP 508](https://www.python.org/dev/peps/pep-0631/)
 - [PEP 633 – Dependency specification in pyproject.toml using an exploded TOML table](https://www.python.org/dev/peps/pep-0633/)
+- [PEP 650 – Specifying Installer Requirements for Python Projects](https://www.python.org/dev/peps/pep-0650/)
 - [PEP 665 – A file format to list Python dependencies for reproducibility of an application](https://peps.python.org/pep-0665/)
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[PEP 660 -- Editable installs for pyproject.toml based builds (wheel based)](https://peps.python.org/pep-0660/)

### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [ ] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- ~~I am making an individual pull request for each entry~~
- [ ] I have added a useful title to the commit
- [ ] I have added a useful title to this PR
- [ ] I have added the new entry in alphabetical order
- [ ] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
-  ~~The new entry meets one of these categories:~~
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
