### PR TITLE
Move setuptools to projects already supporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Do you know of any other project not included here? Please
 - [pip](https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support) - The package installer for Python. You can use pip to install packages from the Python Package Index and other indexes.
 - [Poetry](https://python-poetry.org/docs/pyproject/) - A tool for dependency management and packaging in Python. It allows you to declare the libraries your project depends on and it will manage (install/update) them for you.
 - [Pyflow](https://github.com/David-OConnor/pyflow) - An installation and dependency system for Python.
+- [setuptools](https://github.com/pypa/setuptools) - Easily download, build, install, upgrade, and uninstall Python packages.
 - [setuptools_scm](https://github.com/pypa/setuptools_scm) - Handles managing your Python package versions in SCM metadata instead of declaring them as the version argument or in a SCM managed file.
 
 
@@ -165,7 +166,6 @@ These entries link directly to the project discussion.
 - [pyup](https://github.com/pyupio/pyup/issues/332) - tool to update your project's dependencies on GitHub. Runs on pyup.io, comes with a command line interface.
 - [Radon](https://github.com/rubik/radon/issues/220) - A Python tool that computes various metrics from the source code.
 - [readthedocs.org](https://github.com/readthedocs/readthedocs.org/issues/7065) - Read the Docs hosts documentation for the open source community.
-- [setuptools](https://github.com/pypa/setuptools/issues/1688) - Easily download, build, install, upgrade, and uninstall Python packages.
 - [Spack](https://github.com/spack/spack/issues/6629) - A flexible package manager that supports multiple versions, configurations, platforms, and compilers.
 
 


### PR DESCRIPTION
### Resource description

Since version 61.0.0, setuptools supports configuration via pyproject.toml, [source](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).


### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
