### PR TITLE
Replace Flake9 with flake8-pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Do you know of any other project not included here? Please
 - [Bandit](https://bandit.readthedocs.io/en/latest/config.html) - A tool designed to find common security issues in Python code.
 - [deptry](https://github.com/fpgmaas/deptry) - A command line tool to check for issues with dependencies in a Python project, such as obsolete or missing dependencies.
 - [FlakeHell](https://flakehell.readthedocs.io/config.html) - Flake8 wrapper to make it nice, legacy-friendly, configurable.
-- [Flake9](https://gitlab.com/retnikt/flake9) - Flake8 fork that supports reading config from `pyproject.toml` files.
+- [flake8-pyproject](https://pypi.org/project/Flake8-pyproject/) - Plugin for Flake8 that reads configuration from pyproject.toml and injects the config into Flake8
 - [import-linter](https://import-linter.readthedocs.io/en/stable/usage.html) - Import Linter defines and enforces rules for the imports within and between Python packages.
 - [interrogate](https://interrogate.readthedocs.io/en/latest/#other-usage) - Interrogate a codebase for docstring coverage.
 - [Mypy](https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file) - An optional static type checker for Python (PEP 484).


### PR DESCRIPTION
### Resource description

Flake9 seems to be dead (last commit > 2 years ago). flake8-pyproject is still being actively developed.

flake8-pyproject is a plugin for Flake8 that reads config from pyproject.toml and injects the config into Flake8.

Closes #66 

### By submitting this pull request I confirm I've read and complied with the below requirements

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is configured via its own tool sub-table in the pyproject.toml file (i.e., `[tool.xxx]`)
    - Is a project template using the pyproject.toml file
    - Is an article about the pyproject.toml file
    - Is a link to a project discussion about pyproject.toml support
