### PR TITLE
Add link to FawltyDeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Do you know of any other project not included here? Please
 - [BeeWare Briefcase](https://briefcase.readthedocs.io/en/latest/reference/configuration.html) - Tools to support converting a Python project into a standalone native application.
 - [check-wheel-contents](https://github.com/jwodder/check-wheel-contents) - Check your wheels have the right contents.
 - [DepHell](https://dephell.readthedocs.io/config.html) - Project management for Python. Manage packages: convert between formats, lock, install, resolve, isolate, test, build graph, show outdated, audit. Manage venvs, build package, bump version.
+- [FawltyDeps](https://github.com/tweag/FawltyDeps) - Find undeclared and unused dependencies in your Python project. Verify that your declared dependencies (in `pyproject.toml` or elsewhere) match what you actually `import` in your code.
 - [Flit](https://flit.readthedocs.io/en/stable/pyproject_toml.html) - A simple way to put Python packages and modules on PyPI.
 - [Hatch](https://hatch.pypa.io/latest/config/metadata/) - Modern, extensible Python project manager.
 - [Maturin](https://github.com/PyO3/maturin/blob/main/README.md#python-metadata) - Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages.


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
FawltyDeps is a tool to find discrepancies between your declared dependencies (from `pyproject.toml`, `requirements.txt`, `setup.py`, or `setup.cfg` files), and the 3rd-party modules you `import` in your Python code. FawltyDeps reports _undeclared_ dependencies (i.e. things you `import` but don't declare as a dependency) as well as _unused_ dependencies (i.e. packages you depend on, but never `import`). FawltyDeps itself is highly configurable via its own `[tool.fawltydeps]` section in `pyproject.toml`.

### By submitting this pull request I confirm I've read and complied with the below requirements

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-pyproject/blob/master/contributing.md)
- [x] I am making an individual pull request for each entry
- [x] I have added a useful title to the commit
- [x] I have added a useful title to this PR
- [x] I have added the new entry in alphabetical order
- [x] I have used the following format:
  ```
  - [Resource Title](link) - Resource short Description (2 lines or less in total)
  ```
- [x] The new entry meets one of these categories:
    - Is using `pyproject.toml` as an input to learn about the dependencies of your project.
    - Is configured via its own tool sub-table in the pyproject.toml file: `[tool.fawltydeps]`
